### PR TITLE
Fix blank docs

### DIFF
--- a/cookie_consent/templatetags/cookie_consent_tags.py
+++ b/cookie_consent/templatetags/cookie_consent_tags.py
@@ -141,6 +141,7 @@ def accepted_cookies(request):
     """
     Filter returns accepted cookies varnames.
 
+    Example:
     ::
         {{ request|accepted_cookies }}
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
-import sys, os, django
+import sys, os, django, pathlib
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+root_dir = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, root_dir.resolve())
 sys.path.append(os.path.abspath('.'))
 sys.path.append(os.path.abspath('..'))
 sys.path.append(os.path.abspath('../tests'))
-sys.path.insert(0, os.path.abspath(os.path.join('..', '..', 'cookie_consent')))
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 django.setup()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import sys, os
+import sys, os, django
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -7,7 +7,10 @@ import sys, os
 sys.path.append(os.path.abspath('.'))
 sys.path.append(os.path.abspath('..'))
 sys.path.append(os.path.abspath('../tests'))
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..', 'cookie_consent')))
+
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+django.setup()
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -26,9 +26,9 @@ Settings
   Default: ``True``
 
 ``COOKIE_CONSENT_OPT_OUT``
-  Boolean value represents if cookies are opt-in or opt-out
-  opt-out cookies are set until declined
-  opt-in cookies are set only if accepted
+  Boolean value represents if cookies are opt-in or opt-out.
+  Opt-out cookies are set until declined.
+  Opt-in cookies are set only if accepted.
 
   Default: ``False``
 


### PR DESCRIPTION
Solves #14

There is also the warning of:

WARNING: html_static_path entry '_static' does not exist

To resolve the warning we would change:

`html_static_path = ['_static']`

to:

`html_static_path = []`

But not sure if we want to do that. I'll let the maintainers decide. 