### PR TITLE
Swap changing expires timestamp value with seconds non-changing value

### DIFF
--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -5,7 +5,7 @@ from appconf import AppConf
 
 
 class CookieConsentConf(AppConf):
-    NAME = b"cookie_consent"
+    NAME = "cookie_consent"
     MAX_AGE = 60 * 60 * 24 * 365 * 1  # 1 year
     DECLINE = "-1"
 

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -5,7 +5,7 @@ from appconf import AppConf
 
 
 class CookieConsentConf(AppConf):
-    NAME = "cookie_consent"
+    NAME = b"cookie_consent"
     MAX_AGE = 60 * 60 * 24 * 365 * 1  # 1 year
     DECLINE = "-1"
 

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -151,12 +151,10 @@ def get_cookie_string(cookie_dic):
     """
     Returns cookie in format suitable for use in javascript.
     """
-    expires = datetime.datetime.now() + datetime.timedelta(
-        seconds=settings.COOKIE_CONSENT_MAX_AGE)
     cookie_str = "%s=%s; expires=%s; path=/" % (
         settings.COOKIE_CONSENT_NAME,
         dict_to_cookie_str(cookie_dic),
-        expires.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        settings.COOKIE_CONSENT_MAX_AGE
     )
     return cookie_str
 

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -151,7 +151,7 @@ def get_cookie_string(cookie_dic):
     """
     Returns cookie in format suitable for use in javascript.
     """
-    cookie_str = "%s=%s; expires=%s; path=/" % (
+    cookie_str = "%s=%s; max-age=%s; path=/" % (
         settings.COOKIE_CONSENT_NAME,
         dict_to_cookie_str(cookie_dic),
         settings.COOKIE_CONSENT_MAX_AGE


### PR DESCRIPTION
The expiration time changes every time you do a browser refresh. This causes the cache to fill up quickly because every page the user visits, the source code is different each time due to the new expiration timestamp value. Changing this to a static non-changing value of settings.COOKIE_CONSENT_MAX_AGE will display the seconds a cookie will last and this value will not change unless the django developer changes the settings.COOKIE_CONSENT_MAX_AGE in their settings. 

Related issue: #49 

I am not sure how to do the javascript suggestion as shown in that issue. I will need someone else to make a PR if they want to implement a solution using that method. 