### PR TITLE
Add new settings

### DIFF
--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -24,5 +24,3 @@ class CookieConsentConf(AppConf):
     SECURE = True
 
     HTTPONLY = True
-
-    SIGNED = True

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -5,7 +5,7 @@ from appconf import AppConf
 
 
 class CookieConsentConf(AppConf):
-    NAME = b"cookie_consent"
+    NAME = "cookie_consent"
     MAX_AGE = 60 * 60 * 24 * 365 * 1  # 1 year
     DECLINE = "-1"
 

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -16,3 +16,13 @@ class CookieConsentConf(AppConf):
     CACHE_BACKEND = "default"
 
     LOG_ENABLED = True
+
+    SAMESITE = 'strict'
+
+    DOMAIN = '127.0.0.1'
+
+    SECURE = True
+
+    HTTPONLY = True
+
+    SIGNED = True

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -5,7 +5,7 @@ from appconf import AppConf
 
 
 class CookieConsentConf(AppConf):
-    NAME = "cookie_consent"
+    NAME = b"cookie_consent"
     MAX_AGE = 60 * 60 * 24 * 365 * 1  # 1 year
     DECLINE = "-1"
 

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -36,9 +36,24 @@ def get_cookie_dict_from_request(request):
 
 
 def set_cookie_dict_to_response(response, dic):
-    response.set_cookie(settings.COOKIE_CONSENT_NAME,
-                        dict_to_cookie_str(dic),
-                        settings.COOKIE_CONSENT_MAX_AGE)
+    if settings.COOKIE_CONSENT_SIGNED:
+        response.set_signed_cookie(settings.COOKIE_CONSENT_NAME,
+                            dict_to_cookie_str(dic),
+                            expires=settings.COOKIE_CONSENT_MAX_AGE,
+                            domain=settings.COOKIE_CONSENT_DOMAIN,
+                            samesite=settings.COOKIE_CONSENT_SAMESITE,
+                            secure=settings.COOKIE_CONSENT_SECURE,
+                            httponly=settings.COOKIE_CONSENT_HTTPONLY
+                            )
+    else:
+        response.set_cookie(settings.COOKIE_CONSENT_NAME,
+                            dict_to_cookie_str(dic),
+                            expires=settings.COOKIE_CONSENT_MAX_AGE,
+                            domain=settings.COOKIE_CONSENT_DOMAIN,
+                            samesite=settings.COOKIE_CONSENT_SAMESITE,
+                            secure=settings.COOKIE_CONSENT_SECURE,
+                            httponly=settings.COOKIE_CONSENT_HTTPONLY
+                            )
 
 
 def get_cookie_value_from_request(request, varname, cookie=None):

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -36,24 +36,14 @@ def get_cookie_dict_from_request(request):
 
 
 def set_cookie_dict_to_response(response, dic):
-    if settings.COOKIE_CONSENT_SIGNED:
-        response.set_signed_cookie(settings.COOKIE_CONSENT_NAME,
-                            dict_to_cookie_str(dic),
-                            expires=settings.COOKIE_CONSENT_MAX_AGE,
-                            domain=settings.COOKIE_CONSENT_DOMAIN,
-                            samesite=settings.COOKIE_CONSENT_SAMESITE,
-                            secure=settings.COOKIE_CONSENT_SECURE,
-                            httponly=settings.COOKIE_CONSENT_HTTPONLY
-                            )
-    else:
-        response.set_cookie(settings.COOKIE_CONSENT_NAME,
-                            dict_to_cookie_str(dic),
-                            expires=settings.COOKIE_CONSENT_MAX_AGE,
-                            domain=settings.COOKIE_CONSENT_DOMAIN,
-                            samesite=settings.COOKIE_CONSENT_SAMESITE,
-                            secure=settings.COOKIE_CONSENT_SECURE,
-                            httponly=settings.COOKIE_CONSENT_HTTPONLY
-                            )
+    response.set_cookie(settings.COOKIE_CONSENT_NAME,
+                        dict_to_cookie_str(dic),
+                        expires=settings.COOKIE_CONSENT_MAX_AGE,
+                        domain=settings.COOKIE_CONSENT_DOMAIN,
+                        samesite=settings.COOKIE_CONSENT_SAMESITE,
+                        secure=settings.COOKIE_CONSENT_SECURE,
+                        httponly=settings.COOKIE_CONSENT_HTTPONLY
+                        )
 
 
 def get_cookie_value_from_request(request, varname, cookie=None):

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -38,6 +38,31 @@ Settings
   Default: ``default``
 
 ``COOKIE_CONSENT_LOG_ENABLED``
-  Boolean value represents if user actions when they accepting and declining cookies will be logged. Turning it off might be useful for preventing your database from getting filled up with log items.
+  Boolean value representing if logging is turned on or off for when users accept/decline cookies. Turning it off might be useful for preventing your database from getting filled up with log items.
 
   Default: ``True`` 
+
+``COOKIE_CONSENT_SAMESITE``
+  Boolean value representing the samesite attribute for the consent cookie which should be restricted to a first-party or same-site context. 
+
+  Default: ``True`` 
+
+``COOKIE_CONSENT_DOMAIN``
+  String value representing the domain attribute for the consent cookie. This value should be the root domain. All subdomains part of the root domain will also have the consent cookie. 
+
+  Default: ``127.0.0.1``
+
+``COOKIE_CONSENT_SECURE``
+  Boolean value representing the secure attribute for the consent cookie. A value of True means the cookie will be sent to the server over an encrypted request over HTTPS. 
+
+  Default: ``True``
+
+``COOKIE_CONSENT_HTTPONLY``
+  Boolean value representing the httponly attribute for the consent cookie. A value of True causes the consent cookie to be inaccessible to the JavaScript Document.cookoie API and it will instead only be sent to the server which helps against XSS attacks. 
+
+  Default: ``True``
+
+``COOKIE_CONSENT_SIGNED``
+  Boolean value representing whether the consent cookie is signed or unsigned. A signed cookie has a signature to detect if the client modified the cookie. 
+
+  Default: ``True``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -61,8 +61,3 @@ Settings
   Boolean value representing the httponly attribute for the consent cookie. A value of True causes the consent cookie to be inaccessible to the JavaScript Document.cookie API and it will instead only be sent to the server which helps against XSS attacks. 
 
   Default: ``True``
-
-``COOKIE_CONSENT_SIGNED``
-  Boolean value representing whether the consent cookie is signed or unsigned. A signed cookie has a signature to detect if the client modified the cookie. 
-
-  Default: ``True``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -58,7 +58,7 @@ Settings
   Default: ``True``
 
 ``COOKIE_CONSENT_HTTPONLY``
-  Boolean value representing the httponly attribute for the consent cookie. A value of True causes the consent cookie to be inaccessible to the JavaScript Document.cookoie API and it will instead only be sent to the server which helps against XSS attacks. 
+  Boolean value representing the httponly attribute for the consent cookie. A value of True causes the consent cookie to be inaccessible to the JavaScript Document.cookie API and it will instead only be sent to the server which helps against XSS attacks. 
 
   Default: ``True``
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -43,9 +43,9 @@ Settings
   Default: ``True`` 
 
 ``COOKIE_CONSENT_SAMESITE``
-  Boolean value representing the samesite attribute for the consent cookie which should be restricted to a first-party or same-site context. 
+  String value representing the samesite attribute for the consent cookie which should be restricted to a first-party or same-site context. 
 
-  Default: ``True`` 
+  Default: ``strict`` 
 
 ``COOKIE_CONSENT_DOMAIN``
   String value representing the domain attribute for the consent cookie. This value should be the root domain. All subdomains part of the root domain will also have the consent cookie. 


### PR DESCRIPTION
I decided to add new custom settings for the cookie attributes and also allowed the creation of a signed consent cookie. I made the attributes to be the most secure by default and I wanted to make them separate from:

settings.SESSION_COOKIE_DOMAIN
settings.SESSION_COOKIE_SAMESITE
settings.SESSION_COOKIE_SECURE
settings.SESSION_COOKIE_HTTPONLY

Note: It might be better to keep the domain setting out so that any domain can accept the cookies and you are not limited to just 1. 