### PR TITLE
Updating the CookieGroupBaseProcessView class in cookie_consent.views

### DIFF
--- a/cookie_consent/compat.py
+++ b/cookie_consent/compat.py
@@ -2,3 +2,8 @@ try:
     from django.utils.http import url_has_allowed_host_and_scheme
 except ImportError:  # django < 3.0
     from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+    
+try:
+    from django.contrib.auth.views import SuccessURLAllowedHostsMixin as redirect_url
+except ImportError:  # django >= 4.1
+    from django.contrib.auth.views import RedirectURLMixin as redirect_url

--- a/cookie_consent/views.py
+++ b/cookie_consent/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core.exceptions import SuspiciousOperation
-from django.contrib.auth.views import RedirectURLMixin
+from .compat import redirect_url
 from django.http import HttpResponseRedirect, HttpResponse
 from django.urls import reverse
 from django.views.generic import (
@@ -25,7 +25,7 @@ class CookieGroupListView(ListView):
     model = CookieGroup
 
 
-class CookieGroupBaseProcessView(RedirectURLMixin, View):
+class CookieGroupBaseProcessView(redirect_url, View):
 
     def get_success_url(self):
         """

--- a/cookie_consent/views.py
+++ b/cookie_consent/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core.exceptions import SuspiciousOperation
-from django.contrib.auth.views import SuccessURLAllowedHostsMixin
+from django.contrib.auth.views import RedirectURLMixin
 from django.http import HttpResponseRedirect, HttpResponse
 from django.urls import reverse
 from django.views.generic import (
@@ -25,7 +25,7 @@ class CookieGroupListView(ListView):
     model = CookieGroup
 
 
-class CookieGroupBaseProcessView(SuccessURLAllowedHostsMixin, View):
+class CookieGroupBaseProcessView(RedirectURLMixin, View):
 
     def get_success_url(self):
         """


### PR DESCRIPTION
The SuccessURLAllowedHostsMixin was replaced by RedirectURLMixin as per Django 4.1 documentation "The undocumented django.contrib.auth.views.SuccessURLAllowedHostsMixin mixin is replaced by RedirectURLMixin."

Source
https://docs.djangoproject.com/en/4.1/releases/4.1/