### PR TITLE
Confirm Django 4.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
-        django: ['3.2', '4.0', '4.1']
+        django: ['3.2', '4.1']
 
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
-        django: ['3.2', '4.1']
+        django: ['3.2', '4.1', '4.2']
 
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         python: ['3.8', '3.9', '3.10']
         django: ['3.2', '4.0', '4.1']
-        include:
-          - python: '3.7'
-            django: '3.2'
 
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
       matrix:
         python: ['3.8', '3.9', '3.10']
         django: ['3.2', '4.1', '4.2']
-
+        include:
+          - python: '3.11'
+            django: '4.1'
+          - python: '3.11'
+            django: '4.2'
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -7,13 +7,7 @@ on:
       - master
     tags:
       - '*'
-    paths:
-      - '**.py'
-      - '**.cfg'
   pull_request:
-    paths:
-      - '**.py'
-      - '**.cfg'
   workflow_dispatch:
 
 jobs:

--- a/cookie_consent/apps.py
+++ b/cookie_consent/apps.py
@@ -1,5 +1,8 @@
 from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
 
 
 class CookieConsentConf(AppConfig):
     name = "cookie_consent"
+    verbose_name = _("cookie consent")
+    default_auto_field = "django.db.models.AutoField"

--- a/cookie_consent/migrations/0001_initial.py
+++ b/cookie_consent/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/cookie_consent/migrations/0002_auto__add_logitem.py
+++ b/cookie_consent/migrations/0002_auto__add_logitem.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("cookie_consent", "0001_initial"),
     ]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,7 +5,7 @@ Usage
 Checking for cookie consent in views
 ------------------------------------
 
-::
+.. code-block:: python
 
   from cookie_consent.util import get_cookie_value_from_request
 
@@ -14,7 +14,9 @@ Checking for cookie consent in views
     if cc:
       # add cookie
 
-Checking if specific cookie in Cookie group is accepted is possible::
+Checking if specific cookie in Cookie group is accepted is possible:
+
+.. code-block:: python
 
     cc = get_cookie_value_from_request(request, "mycookies", "mycookie1")
 
@@ -23,7 +25,7 @@ Checking for cookie consent in templates
 
 Use ``cookie_group_accepted`` or ``cookie_group_declined`` template filters.
 
-::
+.. code-block:: django
 
   {% load cookie_consent_tags %}
   {% if request|cookie_group_accepted:"analytics" %}
@@ -45,7 +47,7 @@ of javascript code.
 When consent for using specific cookies is given, code can be evaluated
 without reloading page.
 
-::
+.. code-block:: django
 
   {% load cookie_consent_tags %}
   <script type="{% js_type_for_cookie_consent request "social" "*:.google.com" %}" data-varname="social">
@@ -125,4 +127,4 @@ Notes
 =====
 
 * Ensure that the elements with the class names ``cc-cookie-accept`` and
-``cc-cookie-decline`` are present within the content HTML string.
+  ``cc-cookie-decline`` are present within the content HTML string.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Development Status :: 3 - Alpha
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 3.2
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: Unix

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -16,6 +16,8 @@ ROOT_URLCONF = "testapp.urls"
 
 DEBUG = True
 
+USE_TZ = True
+
 STATIC_URL = "/static/"
 TEMPLATES = [
     {

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-django{32,41}
+    py{38,39,310}-django{32,41,42}
     isort
     black
     ; flake8
@@ -17,6 +17,7 @@ python =
 DJANGO =
     3.2: django32
     4.1: django41
+    4.2: django42
 
 [testenv]
 setenv =
@@ -28,6 +29,7 @@ extras =
 deps =
   django32: Django~=3.2.0
   django41: Django~=4.1.0
+  django42: Django~=4.2.0
 commands =
   pytest tests \
    --junitxml=reports/junit.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py37-django32
     py{38,39,310}-django{32,40,41}
     isort
     black
@@ -10,7 +9,6 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-django{32,40,41}
+    py{38,39,310}-django{32,41}
     isort
     black
     ; flake8
@@ -16,7 +16,6 @@ python =
 [gh-actions:env]
 DJANGO =
     3.2: django32
-    4.0: django40
     4.1: django41
 
 [testenv]
@@ -28,7 +27,6 @@ extras =
     coverage
 deps =
   django32: Django~=3.2.0
-  django40: Django~=4.0.0
   django41: Django~=4.1.0
 commands =
   pytest tests \

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{38,39,310}-django{32,41,42}
+    py311-django{41,42}
     isort
     black
     ; flake8
@@ -12,6 +13,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
Closes #86

:boom: This PR drops support for Python 3.7 and Django 4.0 which are (or will soon) not maintained anymore.

Confirmed support for Python 3.11 and Django 4.2