### PR TITLE
Patch/multisite

### DIFF
--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -7,6 +7,12 @@ from .conf import settings
 from .models import ACTION_ACCEPTED, ACTION_DECLINED, LogItem
 
 
+def _consent_domain():
+    if callable(settings.COOKIE_CONSENT_DOMAIN):
+        return settings.COOKIE_CONSENT_DOMAIN()
+    return settings.COOKIE_CONSENT_DOMAIN
+
+
 def parse_cookie_str(cookie):
     dic = {}
     if not cookie:
@@ -31,7 +37,7 @@ def set_cookie_dict_to_response(response, dic):
         settings.COOKIE_CONSENT_NAME,
         dict_to_cookie_str(dic),
         max_age=settings.COOKIE_CONSENT_MAX_AGE,
-        domain=settings.COOKIE_CONSENT_DOMAIN,
+        domain=_consent_domain(),
         secure=settings.COOKIE_CONSENT_SECURE or None,
         httponly=settings.COOKIE_CONSENT_HTTPONLY or None,
         samesite=settings.COOKIE_CONSENT_SAMESITE,

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -7,9 +7,9 @@ from .conf import settings
 from .models import ACTION_ACCEPTED, ACTION_DECLINED, LogItem
 
 
-def _consent_domain():
+def _consent_domain(request):
     if callable(settings.COOKIE_CONSENT_DOMAIN):
-        return settings.COOKIE_CONSENT_DOMAIN()
+        return settings.COOKIE_CONSENT_DOMAIN(request)
     return settings.COOKIE_CONSENT_DOMAIN
 
 
@@ -32,7 +32,7 @@ def get_cookie_dict_from_request(request):
     return parse_cookie_str(cookie_str)
 
 
-def set_cookie_dict_to_response(response, dic):
+def set_cookie_dict_to_response(request, response, dic):
     response.set_cookie(
         settings.COOKIE_CONSENT_NAME,
         dict_to_cookie_str(dic),
@@ -99,7 +99,7 @@ def accept_cookies(request, response, varname=None):
                 cookiegroup=cookie_group,
                 version=cookie_group.get_version(),
             )
-    set_cookie_dict_to_response(response, cookie_dic)
+    set_cookie_dict_to_response(request, response, cookie_dic)
 
 
 def delete_cookies(response, cookie_group):
@@ -122,7 +122,7 @@ def decline_cookies(request, response, varname=None):
                 cookiegroup=cookie_group,
                 version=cookie_group.get_version(),
             )
-    set_cookie_dict_to_response(response, cookie_dic)
+    set_cookie_dict_to_response(request, response, cookie_dic)
 
 
 def are_all_cookies_accepted(request):

--- a/cookie_consent/util.py
+++ b/cookie_consent/util.py
@@ -37,7 +37,7 @@ def set_cookie_dict_to_response(request, response, dic):
         settings.COOKIE_CONSENT_NAME,
         dict_to_cookie_str(dic),
         max_age=settings.COOKIE_CONSENT_MAX_AGE,
-        domain=_consent_domain(),
+        domain=_consent_domain(request),
         secure=settings.COOKIE_CONSENT_SECURE or None,
         httponly=settings.COOKIE_CONSENT_HTTPONLY or None,
         samesite=settings.COOKIE_CONSENT_SAMESITE,


### PR DESCRIPTION
This patch allows passing of a callable to the `COOKIE_CONSENT_DOMAIN` settings. This is useful for some specific setups of multi-site / multi-tenant Django projects - we're using it inside multi-site Wagtail with a callable in the settings like this...

```
COOKIE_CONSENT_ALLOWED_DOMAINS = [
    'example.test'
    'example.com',
    'subdomain.example.com',
]


def cookie_domain(request):
    full_host = request.get_host()
    domain = full_host.split(':')[0]
    if domain in COOKIE_CONSENT_ALLOWED_DOMAINS:
        return domain
    return "none"


COOKIE_CONSENT_DOMAIN = cookie_domain
```

While making this work, I did discover that actually just returning `None` would set the domain to whatever domain the request was coming from, but that felt like it could be open to abuse so I'm either returning a valid domain or an invalid string.