### PR TITLE
Change order onShow and insert node

### DIFF
--- a/cookie_consent/static/cookie_consent/cookiebar.module.js
+++ b/cookie_consent/static/cookie_consent/cookiebar.module.js
@@ -198,6 +198,6 @@ export const showCookieBar = async (options={}) => {
   // calling the onShow callback
   const cookieBarNode = templateNode.content.firstElementChild.cloneNode(true);
   registerEvents(cookieBarNode, cookieGroups);
-  onShow?.();
   doInsert(cookieBarNode);
+  onShow?.();
 };


### PR DESCRIPTION
I came across the same problem as described [here](https://github.com/jazzband/django-cookie-consent/issues/112#issuecomment-1857767819).

Getting the element in onShow callback to show/activate a modal won't work if doInsert is placed after the callback.

Changing the order seems to work.

