### PR TITLE
Remove Django 3.2 shims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django: ['3.2', '4.2', '5.0']
-        exclude:
-          - python: '3.11'
-            django: '3.2'
-          - python: '3.12'
-            django: '3.2'
+        python: ['3.10', '3.11', '3.12']
+        django: ['4.2', '5.0']
+        include:
           - python: '3.8'
-            django: '5.0'
+            django: '4.2'
           - python: '3.9'
-            django: '5.0'
+            django: '4.2'
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 

--- a/cookie_consent/compat.py
+++ b/cookie_consent/compat.py
@@ -1,8 +1,0 @@
-try:  # django >= 4.1
-    from django.contrib.auth.views import RedirectURLMixin
-except ImportError:
-    from django.contrib.auth.views import (
-        SuccessURLAllowedHostsMixin as RedirectURLMixin,
-    )
-
-__all__ = ["RedirectURLMixin"]

--- a/cookie_consent/views.py
+++ b/cookie_consent/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.contrib.auth.views import RedirectURLMixin
 from django.core.exceptions import SuspiciousOperation
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.middleware.csrf import get_token as get_csrf_token
@@ -6,7 +7,6 @@ from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import ListView, View
 
-from .compat import RedirectURLMixin
 from .models import CookieGroup
 from .util import (
     accept_cookies,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,0 @@
-Django>=1.4
-django-appconf<=1.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,0 @@
--r base.txt
-sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ keywords = cookies, cookie-consent, cookie bar
 classifiers =
     Development Status :: 4 - Beta
     Framework :: Django
-    Framework :: Django :: 3.2
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Intended Audience :: Developers
@@ -40,7 +39,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    django >= 3.2
+    django >= 4.2
     django-appconf
 tests_require =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{38,39}-django{32,42}
-    py310-django32
+    py{38,39}-django42
     py{310,311,312}-django{42,50}
     isort
     black
@@ -19,7 +18,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
     4.2: django42
     5.0: django50
 
@@ -31,7 +29,6 @@ extras =
     tests
     coverage
 deps =
-  django32: Django~=3.2.0
   django42: Django~=4.2.0
   django50: Django~=5.0.0
 commands =
@@ -78,6 +75,5 @@ extras =
     docs
 commands=
     pytest check_sphinx.py -v \
-    --junitxml=../reports/junit.xml \
     --tb=auto \
     {posargs}


### PR DESCRIPTION
Now that Django 3.2 is EOL, we can drop support for it, in the next stable release.

This PR removes the metadata and 3.2 testing in CI + a compatibility shim.