### PR TITLE
Fix onAccept example in JS documentation

### DIFF
--- a/docs/javascript.rst
+++ b/docs/javascript.rst
@@ -197,7 +197,7 @@ and the Javascript function:
 
 .. code-block:: javascript
 
-    function onAccept(event, cookieGroups) {
+    function onAccept(cookieGroups) {
         const analyticsEnabled = cookieGroups.find(group => group.varname === 'analytics') != undefined;
         if (analyticsEnabled) {
             const template = document.getElementById('analytics-scripts').content;


### PR DESCRIPTION
The Javascript integration documentation page includes this sample `onAccept` implementation: 

```javascript
function onAccept(event, cookieGroups) { ... }
```

which won't work as intended, as `cookieGroups` is actually passed as the first parameter to the function. This PR fixes the code sample.