### PR TITLE
:package: Confirm Py 3.13 and Django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
-        django: ['4.2', '5.0']
+        python: ['3.10', '3.11', '3.12', '3.13']
+        django: ['4.2', '5.1', '5.2']
         include:
           - python: '3.8'
             django: '4.2'
           - python: '3.9'
+            django: '4.2'
+        exclude:
+          - python: '3.13'
             django: '4.2'
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
@@ -73,7 +76,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install tox tox-gh-actions pytest-playwright
-          playwright install --with-deps
+          playwright install --with-deps chromium
 
       - name: Run tests
         run: tox -e e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-cookie-consent"
-version = "0.6.0"
 description = "Django cookie consent application"
 authors = [
     {name = "Informatika Mihelac", email = "bmihelac@mihelac.org"}
@@ -16,7 +15,8 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: Unix",
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.8"
@@ -35,6 +36,7 @@ dependencies = [
     "django>=4.2",
     "django-appconf",
 ]
+dynamic = ["version"]
 
 [project.urls]
 Documentation = "https://django-cookie-consent.readthedocs.io/en/latest/"
@@ -63,6 +65,9 @@ release = [
     "tbump",
 ]
 
+[tool.setuptools.dynamic]
+version = {attr = "cookie_consent.__version__"}
+
 [tool.setuptools.packages.find]
 include = ["cookie_consent*"]
 namespaces = true
@@ -80,14 +85,6 @@ testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "testapp.settings"
 markers = [
     "e2e: mark tests as end-to-end tests, using playwright (deselect with '-m \"not e2e\"')",
-]
-
-[tool.bumpversion]
-current_version = "0.1.0"
-files = [
-    {filename = "pyproject.toml"},
-    {filename = "README.rst"},
-    {filename = "docs/conf.py"},
 ]
 
 [tool.coverage.run]

--- a/tbump.toml
+++ b/tbump.toml
@@ -14,10 +14,6 @@ message_template = ":bookmark: Bump to {new_version}"
 tag_template = "{new_version}"
 
 [[file]]
-src = "pyproject.toml"
-version_template = "{major}.{minor}.{patch}{pre}"
-
-[[file]]
 src = "cookie_consent/__init__.py"
 version_template = "{major}.{minor}.{patch}{pre}"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{38,39}-django42
-    py{310,311,312}-django{42,50}
+    py{310,311,312}-django{42,51,52}
+    py{313}-django{51,52}
     isort
     black
     ; flake8
@@ -15,11 +16,13 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
     4.2: django42
-    5.0: django50
+    5.1: django51
+    5.2: django52
 
 [testenv]
 setenv =
@@ -30,7 +33,8 @@ extras =
     coverage
 deps =
   django42: Django~=4.2.0
-  django50: Django~=5.0.0
+  django51: Django~=5.1.0
+  django52: Django~=5.2.0
 commands =
   pytest tests \
    -m 'not e2e' \
@@ -45,7 +49,7 @@ extras =
     tests
     coverage
 deps =
-  Django~=4.2.0
+  Django~=5.2.0
 commands =
   pytest tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \


### PR DESCRIPTION
Additionally this removes the EOL Django 5.0 from the test matrix, while adding 5.1 explicitly.