### PR TITLE
Expose more JS API surface

### DIFF
--- a/js/src/cookiebar.ts
+++ b/js/src/cookiebar.ts
@@ -109,7 +109,14 @@ const DEFAULT_FETCH_HEADERS: Record<string, string> = {
   'X-Cookie-Consent-Fetch': '1'
 };
 
-class FetchClient {
+/**
+ * A simple wrapper around window.fetch that understands the django-cookie-consent
+ * backend endpoints.
+ *
+ * @private - while exported, use at your own risk. This class is not part of the
+ * public API covered by SemVer.
+ */
+export class FetchClient {
   protected statusUrl: string;
   protected csrfHeaderName: string;
   protected cookieStatus: CookieStatus | null;


### PR DESCRIPTION
Closes #126 

Power users can now make use of the fetch client used under the hood, but it (officially) remains private and undocumented API.