### PR TITLE
:boom: Drop python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
         python: ['3.10', '3.11', '3.12', '3.13']
         django: ['4.2', '5.1', '5.2']
         include:
-          - python: '3.8'
-            django: '4.2'
           - python: '3.9'
             django: '4.2'
         exclude:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -104,5 +103,5 @@ exclude_also = [
     "@(abc\\.)?abstractmethod",
     "raise NotImplementedError",
     "\\.\\.\\.",
-    "pass",
+    "\\bpass$",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39}-django42
+    py{39}-django42
     py{310,311,312}-django{42,51,52}
     py{313}-django{51,52}
     isort
@@ -11,7 +11,6 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
It became end of life in October 2024

And is currently preventing us from using a newer setuptools version :) https://github.com/jazzband/django-cookie-consent/actions/runs/15341833268/job/43169387037